### PR TITLE
Ignore metaparams for default translation as well

### DIFF
--- a/lib/puppetx/catalog_translation/type/default_translation.rb
+++ b/lib/puppetx/catalog_translation/type/default_translation.rb
@@ -13,7 +13,11 @@ PuppetX::CatalogTranslation::Type.new :default_translation do
     r_type = @resource.type.to_s
     r_title = @resource[:name]
     r_params = @resource.to_hash.reject { |attr,value|
-      attr == :name
+      [ :name,
+        # ignore relational metaparameters, those are handled through the actual
+        # edges in the RAL graph
+        :before, :require, :notify, :subscribe,
+      ].include? attr
     }
     "puppet yamlresource #{r_type} '#{r_title}' '#{Psych.to_json(r_params).chomp}'"
   end

--- a/spec/integration/catalog_translation_spec.rb
+++ b/spec/integration/catalog_translation_spec.rb
@@ -45,6 +45,19 @@ describe "PuppetX::CatalogTranslation" do
     expect(graph['resources']['exec'][0]['cmd']).to match(/^puppet yamlresource cron 'spec'/)
   end
 
+
+  it "drops relationship metaparams but keeps the relationship" do
+    catalog = resource_catalog('host { "a": before => Host["b"] } host { "b": }')
+    graph = PuppetX::CatalogTranslation.to_mgmt(catalog)
+    expect(graph['resources']['exec'][0]['cmd']).to_not include('before')
+    expect(graph['edges']).to include(
+      {"name"=>"Host[a] -> Host[b]",
+         "from"=>{"kind"=>"exec", "name"=>"Host:a"},
+         "to"=>{"kind"=>"exec", "name"=>"Host:b"}
+      }
+    )
+  end
+
   context "in conservative mode" do
     before :each do
       PuppetX::CatalogTranslation.stubs(:mode).returns(:conservative)


### PR DESCRIPTION
The `before` metaparam causes the generation of an invalid command (on my system at least):

```
super_vagrant@faalserver:/vagrant# puppet yamlresource package 'htop' '{"provider": "apt", "ensure": "latest", "before": [{type: "Package", title: "resolvconf",
            tags: {hash: {"package": true, "resolvconf": true}}, parameters: {}}], "configfiles": "keep",
        "reinstall_on_refresh": "false", "loglevel": "notice"}'
Error: Parameter before failed on Package[htop]: Puppet::Resource.new does not take a hash as the first argument. Did you mean ("Package", "resolvconf") ?
Error: Try 'puppet help yamlresource find_or_save' for usage
```

I have not tested this yet for unwanted side effects. 