### PR TITLE
avoid spawning parameters when they get no value

### DIFF
--- a/lib/puppetx/catalog_translation/type.rb
+++ b/lib/puppetx/catalog_translation/type.rb
@@ -57,7 +57,9 @@ module CatalogTranslation
 
         # spawn additional attributes (watchcmd...)
         if translation[:spawned]
-          result[title] = translation[:block].call
+          value = translation[:block].call
+          next if value.nil?
+          result[title] = value
           next
         end
 

--- a/spec/integration/type_spec.rb
+++ b/spec/integration/type_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'puppet/type/notify'
 
 describe "PuppetX::CatalogTranslation::Type" do
 
@@ -31,6 +32,14 @@ describe "PuppetX::CatalogTranslation::Type" do
       output = PuppetX::CatalogTranslation::Type.dump_error_log.lines
       output *= "\n"
       expect(output).to include('Schedule')
+    end
+  end
+
+  describe ".spawn" do
+    it "drops parameters that yield a nil value" do
+      type = PuppetX::CatalogTranslation::Type.new(:spec) { spawn(:unwanted) { nil } }
+      out_type, params = type.translate!(Puppet::Type::Notify.new(:name => "spec-notify"))
+      expect(params).to_not include(:unwanted)
     end
   end
 


### PR DESCRIPTION
We ran into issue when the YAML for mgmt contained unused empty values
such as `content` for `file` resources that didn't manage content.
If the block for a given spawned parameter returns nil, the translation
engine will stop spawning the parameter in the first place.

Fixes #11