### PR TITLE
Use the rest terminus for fetching catalog

### DIFF
--- a/lib/puppetx/catalog_translation.rb
+++ b/lib/puppetx/catalog_translation.rb
@@ -63,6 +63,8 @@ module PuppetX::CatalogTranslation
       Puppet[:log_level] = "warning"
       reset_log_level = true
     end
+    Puppet::Resource::Catalog.indirection.terminus_class = :rest
+    Puppet::Resource::Catalog.indirection.cache_class = nil
     catalog = Puppet::Face[:catalog, "0.0"].find
     if reset_log_level
       Puppet[:log_level] = "notice"


### PR DESCRIPTION
Match the `puppet catalog download` command by setting the terminus to
'rest' and disabling caching of the result.

The `puppet catalog find` command can fail to retrieve the catalog from
the puppet master unless using `--terminus rest`, while the `puppet
catalog download` command works consistently.

Defaulting to match the download behaviour that in turn calls find on
the backend seems like it will work for more environments.

Fixes #16